### PR TITLE
Restrict bot to private chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ Example response:
    - "Введите курс UST/RUB на сегодня"
    - "Введите курс CNY/RUB на сегодня"
 
-2. Reply to these messages with the rates (only allowed users can reply)
-3. After both rates are collected, they are automatically saved to the database
+2. Reply to these messages with the rates
+3. Only messages from `TARGET_USER_ID` sent in a private chat with the bot are processed
+4. After both rates are collected, they are automatically saved to the database
 
 ## Security
 

--- a/bot.py
+++ b/bot.py
@@ -4,7 +4,7 @@ from datetime import date
 from decimal import Decimal
 from aiogram import Bot, Dispatcher, F
 from aiogram.types import Message
-from aiogram.enums import ParseMode
+from aiogram.enums import ParseMode, ChatType
 from aiogram.client.default import DefaultBotProperties
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -50,7 +50,11 @@ async def check_repeat_request():
 
 @dp.message(F.text)
 async def handle_currency_message(message: Message):
-    if message.from_user.id != TARGET_USER_ID or not rate_cache.get("requested"):
+    if (
+        message.from_user.id != TARGET_USER_ID
+        or message.chat.type != ChatType.PRIVATE
+        or not rate_cache.get("requested")
+    ):
         return
 
     try:


### PR DESCRIPTION
## Summary
- only react to private chat messages from `TARGET_USER_ID`
- document the restriction in the README

## Testing
- `python -m pip check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684404e15c00832caff025f769bf92dd