### PR TITLE
Enable editing of daily rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Telegram bot for manual collection and storage of currency rates with API access
 - Automatic conversion to smallest units
 - FastAPI backend for rate retrieval
 - PostgreSQL storage
+- Ability to overwrite today's rates by sending them again
 
 ## Setup
 
@@ -74,6 +75,7 @@ Example response:
 2. Reply to these messages with the rates
 3. Only messages from `TARGET_USER_ID` sent in a private chat with the bot are processed
 4. After both rates are collected, they are automatically saved to the database
+5. Sending new rates again on the same day overwrites the previous values
 
 ## Security
 

--- a/bot.py
+++ b/bot.py
@@ -58,9 +58,9 @@ async def handle_currency_message(message: Message):
 
     async with get_session() as session:
         controller = CurrencyController(session)
-        existing = await controller.get_rates_by_date(date.today())
+        has_today = await controller.has_rates_for_date(date.today())
 
-        if not rate_cache.get("requested") and existing is None:
+        if not rate_cache.get("requested") and not has_today:
             return
 
         try:
@@ -99,7 +99,7 @@ async def handle_currency_message(message: Message):
                 f"🇨🇳 CNY: <b>{cny_markup:.2f}₽</b>"
             )
 
-            if existing:
+            if has_today:
                 await message.reply("✅ Курсы обновлены.")
             else:
                 await message.reply("✅ Курсы получены и сохранены.")

--- a/controllers.py
+++ b/controllers.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from datetime import date
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import select, func
 from models import CurrencyRates
 
 class CurrencyController:
@@ -44,6 +44,11 @@ class CurrencyController:
         query = select(CurrencyRates).where(CurrencyRates.date == date)
         result = await self.session.execute(query)
         return result.scalar_one_or_none()
+
+    async def has_rates_for_date(self, date: date) -> bool:
+        query = select(func.count()).select_from(CurrencyRates).where(CurrencyRates.date == date)
+        result = await self.session.execute(query)
+        return result.scalar_one() > 0
 
     async def get_rates_range(self, from_date: Optional[date], to_date: Optional[date]):
         query = select(CurrencyRates)

--- a/controllers.py
+++ b/controllers.py
@@ -16,6 +16,17 @@ class CurrencyController:
         ust_plus1_cents = int((ust + 1) * 100)
         cny_plus2p_fens = int((cny * 1.02) * 100)
 
+        existing = await self.get_rates_by_date(date)
+        if existing:
+            existing.ust_rub_cents = ust_cents
+            existing.cny_rub_fens = cny_fens
+            existing.ust_rub_plus1_cents = ust_plus1_cents
+            existing.cny_rub_plus2p_fens = cny_plus2p_fens
+
+            await self.session.commit()
+            await self.session.refresh(existing)
+            return existing
+
         rates = CurrencyRates(
             date=date,
             ust_rub_cents=ust_cents,


### PR DESCRIPTION
## Summary
- allow `CurrencyController.add_rates` to update existing records
- modify `handle_currency_message` to permit overwriting today's rates
- confirm overwrites to the user
- document rate editing in README

## Testing
- `python -m py_compile bot.py controllers.py api.py models.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_684405a8da70832c8bb2e5fd71900cdb