### PR TITLE
Add noon reminder check

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ Example response:
 1. The bot automatically sends two messages at 09:00 MSK on weekdays (Mon-Fri):
    - "Введите курс UST/RUB на сегодня"
    - "Введите курс CNY/RUB на сегодня"
-
-2. Reply to these messages with the rates
-3. Only messages from `TARGET_USER_ID` sent in a private chat with the bot are processed
-4. After both rates are collected, they are automatically saved to the database
-5. Sending new rates again on the same day overwrites the previous values
+2. If the rates are still not provided, the bot sends a reminder at 12:00 MSK on weekdays
+3. Reply to these messages with the rates
+4. Only messages from `TARGET_USER_ID` sent in a private chat with the bot are processed
+5. After both rates are collected, they are automatically saved to the database
+6. Sending new rates again on the same day overwrites the previous values
 
 ## Security
 

--- a/bot.py
+++ b/bot.py
@@ -42,7 +42,11 @@ async def request_currency_inputs():
         logger.error(f"❌ Ошибка при отправке сообщения: {e}")
 
 async def check_repeat_request():
-    if not rate_cache.get("usd") or not rate_cache.get("cny"):
+    async with get_session() as session:
+        controller = CurrencyController(session)
+        rates = await controller.get_rates_by_date(date.today())
+
+    if rates is None:
         logger.info("🔁 Повторный запрос курсов в 12:00")
         await request_currency_inputs()
 
@@ -114,10 +118,10 @@ async def main():
         request_currency_inputs,
         CronTrigger(hour=10, minute=0, day_of_week="mon-fri"),
     )
-    # scheduler.add_job(
-    #     check_repeat_request,
-    #     CronTrigger(hour=12, minute=0, day_of_week="mon-fri"),
-    # )
+    scheduler.add_job(
+        check_repeat_request,
+        CronTrigger(hour=12, minute=0, day_of_week="mon-fri"),
+    )
     scheduler.start()
 
     logger.info("🚀 Бот запущен и готов принимать сообщения")


### PR DESCRIPTION
## Summary
- send a repeat request if no rates are recorded in DB
- enable noon reminder scheduling
- document reminder in README

## Testing
- `python -m py_compile bot.py controllers.py database.py api.py models.py logger.py`

------
https://chatgpt.com/codex/tasks/task_e_684408a105f4832c84244bdaf2422a33