### PR TITLE
Add basic web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Telegram bot for manual collection and storage of currency rates with API access
    python bot.py
    ```
 
+## Web Interface
+
+Open `http://localhost:8000/` in your browser after starting the API server.
+Select a date range and click **Load** to fetch rates via AJAX.
+
 ## API Usage
 
 ### Get Rates by Date

--- a/api.py
+++ b/api.py
@@ -1,4 +1,7 @@
-from fastapi import FastAPI, Depends, HTTPException, Query
+from fastapi import FastAPI, Depends, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 from datetime import date
 from typing import Optional, List, AsyncGenerator
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -8,6 +11,8 @@ from database import get_session
 from controllers import CurrencyController
 
 app = FastAPI(title="Currency Rates API")
+templates = Jinja2Templates(directory="templates")
+app.mount("/static", StaticFiles(directory="static"), name="static")
 
 async def get_db_session() -> AsyncGenerator[AsyncSession, None]:
     async with get_session() as session:
@@ -85,3 +90,8 @@ async def get_rates_range(
             "cny_rub_plus2p": r.cny_rub_plus2p_fens / 100
         } for r in result
     ]
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,29 @@
+const form = document.getElementById('range-form');
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const fromDate = document.getElementById('from_date').value;
+    const toDate = document.getElementById('to_date').value;
+
+    const params = new URLSearchParams();
+    if (fromDate) params.append('from_date', fromDate);
+    if (toDate) params.append('to_date', toDate);
+
+    const resp = await fetch(`/rates?${params.toString()}`);
+    if (!resp.ok) {
+        alert('Failed to load data');
+        return;
+    }
+    const data = await resp.json();
+    const tbody = document.getElementById('rates-table-body');
+    tbody.innerHTML = '';
+    data.forEach(r => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+            <td>${r.date}</td>
+            <td>${r.ust_rub}</td>
+            <td>${r.cny_rub}</td>
+            <td>${r.ust_rub_plus1}</td>
+            <td>${r.cny_rub_plus2p}</td>`;
+        tbody.appendChild(row);
+    });
+});

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,19 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-top: 10px;
+}
+
+table, th, td {
+    border: 1px solid #ccc;
+}
+
+th, td {
+    padding: 8px;
+    text-align: left;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Currency Rates</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+    <h1>Currency Rates</h1>
+    <form id="range-form">
+        <label>From: <input type="date" id="from_date" name="from_date"></label>
+        <label>To: <input type="date" id="to_date" name="to_date"></label>
+        <button type="submit">Load</button>
+    </form>
+    <table>
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>USD/RUB</th>
+                <th>CNY/RUB</th>
+                <th>USD+1</th>
+                <th>CNY+2%</th>
+            </tr>
+        </thead>
+        <tbody id="rates-table-body">
+        </tbody>
+    </table>
+    <script src="/static/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve frontend templates via Jinja2Templates
- add static files for styling and JS
- create a simple index page that queries the `/rates` API
- document the new web UI in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68440adb0fd0832c9184a6ad783c5c79