### PR TITLE
Add Russian UI with weekly default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Telegram bot for manual collection and storage of currency rates with API access
 ## Web Interface
 
 Open `http://localhost:8000/` in your browser after starting the API server.
-Select a date range and click **Load** to fetch rates via AJAX.
+The page is in Russian and immediately shows rates for the last 7 days.
+The latest available rate is displayed above the form.
+Select another date range and click **Загрузить** to update the table.
 
 ## API Usage
 
@@ -86,4 +88,4 @@ Example response:
 
 - Only whitelisted users can reply to rate collection messages
 - API can be protected with API key (implementation required)
-- All monetary values are stored as integers (cents/fens) 
+- All monetary values are stored as integers (cents/fens)

--- a/api.py
+++ b/api.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from datetime import date
+from datetime import date, timedelta
 from typing import Optional, List, AsyncGenerator
 from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import BaseModel
@@ -93,5 +93,36 @@ async def get_rates_range(
 
 
 @app.get("/", response_class=HTMLResponse)
-async def index(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+async def index(request: Request, session: AsyncSession = Depends(get_db_session)):
+    today = date.today()
+    week_ago = today - timedelta(days=6)
+    controller = CurrencyController(session)
+    week_rates_models = await controller.get_rates_range(week_ago, today)
+    week_rates = [
+        {
+            "date": r.date,
+            "ust_rub": r.ust_rub_cents / 100,
+            "cny_rub": r.cny_rub_fens / 100,
+            "ust_rub_plus1": r.ust_rub_plus1_cents / 100,
+            "cny_rub_plus2p": r.cny_rub_plus2p_fens / 100,
+        }
+        for r in week_rates_models
+    ]
+
+    latest = await controller.get_latest_rate()
+    latest_data = None
+    if latest:
+        latest_data = {
+            "date": latest.date,
+            "ust_rub": latest.ust_rub_cents / 100,
+            "cny_rub": latest.cny_rub_fens / 100,
+        }
+
+    context = {
+        "request": request,
+        "default_rates": week_rates,
+        "latest_rate": latest_data,
+        "from_date": week_ago.isoformat(),
+        "to_date": today.isoformat(),
+    }
+    return templates.TemplateResponse("index.html", context)

--- a/controllers.py
+++ b/controllers.py
@@ -59,3 +59,8 @@ class CurrencyController:
         query = query.order_by(CurrencyRates.date)
         result = await self.session.execute(query)
         return result.scalars().all()
+
+    async def get_latest_rate(self) -> CurrencyRates | None:
+        query = select(CurrencyRates).order_by(CurrencyRates.date.desc()).limit(1)
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()

--- a/static/script.js
+++ b/static/script.js
@@ -10,7 +10,7 @@ form.addEventListener('submit', async (e) => {
 
     const resp = await fetch(`/rates?${params.toString()}`);
     if (!resp.ok) {
-        alert('Failed to load data');
+        alert('Не удалось загрузить данные');
         return;
     }
     const data = await resp.json();
@@ -20,10 +20,10 @@ form.addEventListener('submit', async (e) => {
         const row = document.createElement('tr');
         row.innerHTML = `
             <td>${r.date}</td>
-            <td>${r.ust_rub}</td>
-            <td>${r.cny_rub}</td>
-            <td>${r.ust_rub_plus1}</td>
-            <td>${r.cny_rub_plus2p}</td>`;
+            <td>${r.ust_rub.toFixed(2)}</td>
+            <td>${r.cny_rub.toFixed(2)}</td>
+            <td>${r.ust_rub_plus1.toFixed(2)}</td>
+            <td>${r.cny_rub_plus2p.toFixed(2)}</td>`;
         tbody.appendChild(row);
     });
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,20 +2,29 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Currency Rates</title>
+<title>Курсы валют</title>
     <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
-    <h1>Currency Rates</h1>
+    <h1>Курсы валют</h1>
+
+    {% if latest_rate %}
+    <div id="latest-rate">
+        Актуальный курс на {{ latest_rate.date }}:
+        USD/RUB {{ "%.2f"|format(latest_rate.ust_rub) }},
+        CNY/RUB {{ "%.2f"|format(latest_rate.cny_rub) }}
+    </div>
+    {% endif %}
+
     <form id="range-form">
-        <label>From: <input type="date" id="from_date" name="from_date"></label>
-        <label>To: <input type="date" id="to_date" name="to_date"></label>
-        <button type="submit">Load</button>
+        <label>С: <input type="date" id="from_date" name="from_date" value="{{ from_date }}"></label>
+        <label>По: <input type="date" id="to_date" name="to_date" value="{{ to_date }}"></label>
+        <button type="submit">Загрузить</button>
     </form>
     <table>
         <thead>
             <tr>
-                <th>Date</th>
+                <th>Дата</th>
                 <th>USD/RUB</th>
                 <th>CNY/RUB</th>
                 <th>USD+1</th>
@@ -23,6 +32,15 @@
             </tr>
         </thead>
         <tbody id="rates-table-body">
+            {% for r in default_rates %}
+            <tr>
+                <td>{{ r.date }}</td>
+                <td>{{ "%.2f"|format(r.ust_rub) }}</td>
+                <td>{{ "%.2f"|format(r.cny_rub) }}</td>
+                <td>{{ "%.2f"|format(r.ust_rub_plus1) }}</td>
+                <td>{{ "%.2f"|format(r.cny_rub_plus2p) }}</td>
+            </tr>
+            {% endfor %}
         </tbody>
     </table>
     <script src="/static/script.js"></script>


### PR DESCRIPTION
## Summary
- localize web interface in Russian
- show latest rate on main page
- pre-load last 7 days of data by default

## Testing
- `python -m py_compile api.py controllers.py`

------
https://chatgpt.com/codex/tasks/task_e_6843ffe21e1c832cab9854b12d899352