### PR TITLE
feat: support multiple allowed users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Telegram bot for manual collection and storage of currency rates with API access
 - Automatic conversion to smallest units
 - FastAPI backend for rate retrieval
 - PostgreSQL storage
-- Ability to overwrite today's rates by sending them again
+- Only the first valid rates per day are saved
 
 ## Setup
 
@@ -24,7 +24,7 @@ Telegram bot for manual collection and storage of currency rates with API access
    ```
    BOT_TOKEN=your_bot_token_here
    TARGET_GROUP_ID=your_group_id_here
-   ALLOWED_USERS=123456789,987654321
+   ALLOWED_USERS=78175979,6107771545,253738991
    DATABASE_URL=postgresql+asyncpg://user:password@localhost/currency_rates
    ```
 
@@ -80,9 +80,9 @@ Example response:
    - "Введите курс CNY/RUB на сегодня"
 2. If the rates are still not provided, the bot sends a reminder at 12:00 MSK on weekdays
 3. Reply to these messages with the rates
-4. Only messages from `TARGET_USER_ID` sent in a private chat with the bot are processed
+4. Only messages from users listed in `ALLOWED_USERS` (and `TARGET_USER_ID` for backward compatibility) sent in a private chat with the bot are processed
 5. After both rates are collected, they are automatically saved to the database
-6. Sending new rates again on the same day overwrites the previous values
+6. Repeated submissions on the same day are ignored
 
 ## Security
 

--- a/bot.py
+++ b/bot.py
@@ -1,47 +1,85 @@
 import os
+import re
 import asyncio
 from datetime import date
 from decimal import Decimal
+
 from aiogram import Bot, Dispatcher, F
-from aiogram.types import Message
-from aiogram.enums import ParseMode, ChatType
 from aiogram.client.default import DefaultBotProperties
+from aiogram.enums import ChatType, ParseMode
+from aiogram.types import Message
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from dotenv import load_dotenv
+from sqlalchemy.exc import IntegrityError
 
 from database import get_session
 from controllers import CurrencyController
 from logger import setup_logger
+
 
 load_dotenv()
 logger = setup_logger(__name__, level="INFO")
 
 bot = Bot(
     token=os.getenv("BOT_TOKEN"),
-    default=DefaultBotProperties(parse_mode=ParseMode.HTML)
+    default=DefaultBotProperties(parse_mode=ParseMode.HTML),
 )
 dp = Dispatcher()
 scheduler = AsyncIOScheduler()
 
-TARGET_USER_ID = int(os.getenv("TARGET_USER_ID"))
+
+# --- Access control ---
+
+
+def _parse_ids(env_value: str) -> set[int]:
+    ids: set[int] = set()
+    for raw in env_value.split(","):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            ids.add(int(raw))
+        except ValueError:
+            logger.warning(f"⚠️ Невалидный ID: {raw}")
+    return ids
+
+
+allowed_users = _parse_ids(os.getenv("ALLOWED_USERS", ""))
+_target = os.getenv("TARGET_USER_ID")
+if _target:
+    try:
+        allowed_users.add(int(_target))
+    except ValueError:
+        logger.warning("⚠️ TARGET_USER_ID не число")
+if not allowed_users:
+    logger.error("❌ Пустой ALLOWED_USERS/TARGET_USER_ID")
+    raise SystemExit(1)
+
+logger.info(f"👥 Допущенные пользователи: {sorted(allowed_users)}")
+
 MANAGER_CHAT_ID = int(os.getenv("MANAGER_CHAT_ID"))
 
-rate_cache = {"requested": False}
+
+CURRENCY_PROMPT = (
+    "📥 Введите курс валют (USD и CNY) в две строки, с учётом вашей наценки:\n\n"
+    "Пример:\n<code>93.15\n12.85</code>"
+)
+
 
 # --- Tasks ---
 
-async def request_currency_inputs():
-    try:
-        await bot.send_message(TARGET_USER_ID,
-            "📥 Введите курс валют (USD и CNY) в две строки, с учётом вашей наценки:\n\n"
-            "Пример:\n<code>93.15\n12.85</code>")
-        rate_cache["requested"] = True
-        logger.info("📩 Запрошены курсы у пользователя")
-    except Exception as e:
-        logger.error(f"❌ Ошибка при отправке сообщения: {e}")
 
-async def check_repeat_request():
+async def request_currency_inputs() -> None:
+    for uid in allowed_users:
+        try:
+            await bot.send_message(uid, CURRENCY_PROMPT)
+            logger.info(f"📩 Запрос курсов отправлен пользователю {uid}")
+        except Exception as e:
+            logger.error(f"❌ Не удалось отправить запрос пользователю {uid}: {e}")
+
+
+async def check_repeat_request() -> None:
     async with get_session() as session:
         controller = CurrencyController(session)
         rates = await controller.get_rates_by_date(date.today())
@@ -50,70 +88,74 @@ async def check_repeat_request():
         logger.info("🔁 Повторный запрос курсов в 12:00")
         await request_currency_inputs()
 
+
+# --- Helpers ---
+
+
+def _extract_two_decimals(text: str) -> tuple[Decimal, Decimal] | None:
+    matches = re.findall(r"[0-9]+(?:[.,][0-9]+)?", text)
+    if len(matches) != 2:
+        return None
+    return tuple(Decimal(m.replace(",", ".")) for m in matches)
+
+
 # --- Handlers ---
 
+
 @dp.message(F.text)
-async def handle_currency_message(message: Message):
-    if (
-        message.from_user.id != TARGET_USER_ID
-        or message.chat.type != ChatType.PRIVATE
-    ):
+async def handle_currency_message(message: Message) -> None:
+    if message.chat.type != ChatType.PRIVATE or message.from_user.id not in allowed_users:
         return
 
     async with get_session() as session:
         controller = CurrencyController(session)
-        has_today = await controller.has_rates_for_date(date.today())
-
-        if not rate_cache.get("requested") and not has_today:
+        if await controller.has_rates_for_date(date.today()):
+            logger.info(f"⛔ Повторный ввод от {message.from_user.id}")
+            await message.reply("ℹ️ Курсы на сегодня уже зафиксированы.")
             return
 
+        pair = _extract_two_decimals(message.text)
+        if pair is None:
+            logger.info(f"⚠️ Неверный формат от {message.from_user.id}: {message.text!r}")
+            await message.reply("❌ Неверный формат. Введите два курса — например:\n<code>93.15 12.85</code>")
+            return
+
+        a, b = pair
+        usd_markup, cny_markup = max(a, b), min(a, b)
+        usd_base = (usd_markup - Decimal("1.00")).quantize(Decimal("0.0001"))
+        cny_base = (cny_markup / Decimal("1.02")).quantize(Decimal("0.0001"))
+
         try:
-            # Извлекаем числа из текста
-            raw_text = message.text.replace(",", ".")
-            parts = [Decimal(p) for p in raw_text.replace("\n", " ").split() if p.replace('.', '', 1).isdigit()]
-
-            if len(parts) != 2:
-                await message.reply("❌ Неверный формат. Введите два курса — например:\n<code>93.15 12.85</code>")
-                return
-
-            usd_markup, cny_markup = max(parts), min(parts)
-
-            # Пересчитываем базовые курсы
-            usd_base = (usd_markup - Decimal("1.00")).quantize(Decimal("0.0001"))
-            cny_base = (cny_markup / Decimal("1.02")).quantize(Decimal("0.0001"))
-
-            rate_cache.update({
-                "usd": usd_base,
-                "cny": cny_base,
-                "requested": False
-            })
-
-            await controller.add_rates(
-                ust=float(usd_base),
-                cny=float(cny_base),
-                date=date.today()
-            )
-
-            logger.info("💾 Курсы успешно сохранены")
-
-            await bot.send_message(
-                MANAGER_CHAT_ID,
-                f"<b>📊 Курсы на {date.today().strftime('%d.%m.%Y')}:</b>\n\n"
-                f"🇺🇸 USD: <b>{usd_markup:.2f}₽</b>\n"
-                f"🇨🇳 CNY: <b>{cny_markup:.2f}₽</b>"
-            )
-
-            if has_today:
-                await message.reply("✅ Курсы обновлены.")
-            else:
-                await message.reply("✅ Курсы получены и сохранены.")
+            await controller.add_rates(ust=float(usd_base), cny=float(cny_base), date=date.today())
+        except IntegrityError:
+            await message.reply("ℹ️ Курсы на сегодня уже зафиксированы.")
+            return
         except Exception as e:
-            logger.warning(f"Ошибка обработки курсов: {e}")
-            await message.reply("❌ Ошибка. Убедитесь, что введены два корректных числа.")
+            logger.warning(f"❌ Ошибка сохранения курсов от {message.from_user.id}: {e}")
+            await message.reply("⚠️ Не удалось сохранить курсы.")
+            return
+
+        logger.info(f"💾 Курсы сохранены от пользователя {message.from_user.id}")
+
+    author = (message.from_user.username and f"@{message.from_user.username}") or str(message.from_user.id)
+    await bot.send_message(
+        MANAGER_CHAT_ID,
+        (
+            f"<b>📊 Курсы на {date.today():%d.%m.%Y} (от {author}):</b>\n\n"
+            f"🇺🇸 USD (введено): <b>{usd_markup:.2f}₽</b>\n"
+            f"🇨🇳 CNY (введено): <b>{cny_markup:.2f}₽</b>\n\n"
+            f"🧮 База:\n"
+            f"• USD(base) = {usd_base:.4f}₽\n"
+            f"• CNY(base) = {cny_base:.4f}₽"
+        ),
+    )
+    await message.reply("✅ Курсы получены и сохранены. Спасибо!")
+
 
 # --- Entry point ---
 
-async def main():
+
+async def main() -> None:
     scheduler.add_job(
         request_currency_inputs,
         CronTrigger(hour=10, minute=0, day_of_week="mon-fri"),
@@ -127,5 +169,7 @@ async def main():
     logger.info("🚀 Бот запущен и готов принимать сообщения")
     await dp.start_polling(bot)
 
+
 if __name__ == "__main__":
     asyncio.run(main())
+

--- a/controllers.py
+++ b/controllers.py
@@ -2,6 +2,7 @@ from typing import Optional
 from datetime import date
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func
+from sqlalchemy.exc import IntegrityError
 from models import CurrencyRates
 
 class CurrencyController:
@@ -12,31 +13,23 @@ class CurrencyController:
         ust_cents = int(ust * 100)
         cny_fens = int(cny * 100)
 
-        # Calculate additional values
         ust_plus1_cents = int((ust + 1) * 100)
         cny_plus2p_fens = int((cny * 1.02) * 100)
-
-        existing = await self.get_rates_by_date(date)
-        if existing:
-            existing.ust_rub_cents = ust_cents
-            existing.cny_rub_fens = cny_fens
-            existing.ust_rub_plus1_cents = ust_plus1_cents
-            existing.cny_rub_plus2p_fens = cny_plus2p_fens
-
-            await self.session.commit()
-            await self.session.refresh(existing)
-            return existing
 
         rates = CurrencyRates(
             date=date,
             ust_rub_cents=ust_cents,
             cny_rub_fens=cny_fens,
             ust_rub_plus1_cents=ust_plus1_cents,
-            cny_rub_plus2p_fens=cny_plus2p_fens
+            cny_rub_plus2p_fens=cny_plus2p_fens,
         )
 
         self.session.add(rates)
-        await self.session.commit()
+        try:
+            await self.session.commit()
+        except IntegrityError:
+            await self.session.rollback()
+            raise
         await self.session.refresh(rates)
         return rates
 


### PR DESCRIPTION
## Summary
- parse ALLOWED_USERS from env and merge with legacy TARGET_USER_ID
- broadcast daily currency requests to all allowed users
- ignore repeated submissions and save only first valid rates per day
- document new whitelist behaviour

## Testing
- `python -m py_compile bot.py controllers.py api.py database.py logger.py models.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e15c3a77c832cb6a9ce3cc9b2fba4