### PR TITLE
Allow updating daily rates and add USDT support

### DIFF
--- a/alembic/versions/5a8b65b7d8d4_add_usdt_rates.py
+++ b/alembic/versions/5a8b65b7d8d4_add_usdt_rates.py
@@ -1,0 +1,39 @@
+"""add usdt rates
+
+Revision ID: 5a8b65b7d8d4
+Revises: 31208e7daede
+Create Date: 2025-05-24 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "5a8b65b7d8d4"
+down_revision: Union[str, None] = "31208e7daede"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "rates",
+        sa.Column("usdt_rub_cents", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "rates",
+        sa.Column("usdt_rub_plus1_cents", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.execute(
+        "UPDATE rates SET usdt_rub_cents = ust_rub_cents, usdt_rub_plus1_cents = ust_rub_plus1_cents"
+    )
+    op.alter_column("rates", "usdt_rub_cents", server_default=None)
+    op.alter_column("rates", "usdt_rub_plus1_cents", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("rates", "usdt_rub_plus1_cents")
+    op.drop_column("rates", "usdt_rub_cents")

--- a/api.py
+++ b/api.py
@@ -21,8 +21,10 @@ async def get_db_session() -> AsyncGenerator[AsyncSession, None]:
 class CurrencyRatesResponse(BaseModel):
     date: date
     ust_rub: float
+    usdt_rub: float
     cny_rub: float
     ust_rub_plus1: float
+    usdt_rub_plus1: float
     cny_rub_plus2p: float
 
     class Config:
@@ -41,9 +43,11 @@ async def get_today_rates(session: AsyncSession = Depends(get_db_session)):
     return {
         "date": rates.date,
         "ust_rub": rates.ust_rub_cents / 100,
+        "usdt_rub": rates.usdt_rub_cents / 100,
         "cny_rub": rates.cny_rub_fens / 100,
         "ust_rub_plus1": rates.ust_rub_plus1_cents / 100,
-        "cny_rub_plus2p": rates.cny_rub_plus2p_fens / 100
+        "usdt_rub_plus1": rates.usdt_rub_plus1_cents / 100,
+        "cny_rub_plus2p": rates.cny_rub_plus2p_fens / 100,
     }
 
 
@@ -66,9 +70,11 @@ async def get_rates_by_date(
     return {
         "date": rates.date,
         "ust_rub": rates.ust_rub_cents / 100,
+        "usdt_rub": rates.usdt_rub_cents / 100,
         "cny_rub": rates.cny_rub_fens / 100,
         "ust_rub_plus1": rates.ust_rub_plus1_cents / 100,
-        "cny_rub_plus2p": rates.cny_rub_plus2p_fens / 100
+        "usdt_rub_plus1": rates.usdt_rub_plus1_cents / 100,
+        "cny_rub_plus2p": rates.cny_rub_plus2p_fens / 100,
     }
 
 
@@ -85,10 +91,13 @@ async def get_rates_range(
         {
             "date": r.date,
             "ust_rub": r.ust_rub_cents / 100,
+            "usdt_rub": r.usdt_rub_cents / 100,
             "cny_rub": r.cny_rub_fens / 100,
             "ust_rub_plus1": r.ust_rub_plus1_cents / 100,
-            "cny_rub_plus2p": r.cny_rub_plus2p_fens / 100
-        } for r in result
+            "usdt_rub_plus1": r.usdt_rub_plus1_cents / 100,
+            "cny_rub_plus2p": r.cny_rub_plus2p_fens / 100,
+        }
+        for r in result
     ]
 
 
@@ -102,8 +111,10 @@ async def index(request: Request, session: AsyncSession = Depends(get_db_session
         {
             "date": r.date,
             "ust_rub": r.ust_rub_cents / 100,
+            "usdt_rub": r.usdt_rub_cents / 100,
             "cny_rub": r.cny_rub_fens / 100,
             "ust_rub_plus1": r.ust_rub_plus1_cents / 100,
+            "usdt_rub_plus1": r.usdt_rub_plus1_cents / 100,
             "cny_rub_plus2p": r.cny_rub_plus2p_fens / 100,
         }
         for r in week_rates_models
@@ -115,6 +126,7 @@ async def index(request: Request, session: AsyncSession = Depends(get_db_session
         latest_data = {
             "date": latest.date,
             "ust_rub": latest.ust_rub_cents / 100,
+            "usdt_rub": latest.usdt_rub_cents / 100,
             "cny_rub": latest.cny_rub_fens / 100,
         }
 

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,7 @@ import os
 import re
 import asyncio
 from datetime import date
-from decimal import Decimal
+from decimal import Decimal, DivisionByZero, InvalidOperation
 
 from aiogram import Bot, Dispatcher, F
 from aiogram.client.default import DefaultBotProperties
@@ -11,8 +11,6 @@ from aiogram.types import Message
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from dotenv import load_dotenv
-from sqlalchemy.exc import IntegrityError
-
 from database import get_session
 from controllers import CurrencyController
 from logger import setup_logger
@@ -62,8 +60,8 @@ MANAGER_CHAT_ID = int(os.getenv("MANAGER_CHAT_ID"))
 
 
 CURRENCY_PROMPT = (
-    "📥 Введите курс валют (USD и CNY) в две строки, с учётом вашей наценки:\n\n"
-    "Пример:\n<code>93.15\n12.85</code>"
+    "📥 Введите курс валют (USD, USDT и CNY) в три строки, с учётом вашей наценки:\n\n"
+    "Пример:\n<code>93.15\n93.55\n12.85</code>"
 )
 
 
@@ -92,9 +90,9 @@ async def check_repeat_request() -> None:
 # --- Helpers ---
 
 
-def _extract_two_decimals(text: str) -> tuple[Decimal, Decimal] | None:
+def _extract_three_decimals(text: str) -> tuple[Decimal, Decimal, Decimal] | None:
     matches = re.findall(r"[0-9]+(?:[.,][0-9]+)?", text)
-    if len(matches) != 2:
+    if len(matches) != 3:
         return None
     return tuple(Decimal(m.replace(",", ".")) for m in matches)
 
@@ -109,47 +107,61 @@ async def handle_currency_message(message: Message) -> None:
 
     async with get_session() as session:
         controller = CurrencyController(session)
-        if await controller.has_rates_for_date(date.today()):
-            logger.info(f"⛔ Повторный ввод от {message.from_user.id}")
-            await message.reply("ℹ️ Курсы на сегодня уже зафиксированы.")
-            return
 
-        pair = _extract_two_decimals(message.text)
-        if pair is None:
+        parsed = _extract_three_decimals(message.text)
+        if parsed is None:
             logger.info(f"⚠️ Неверный формат от {message.from_user.id}: {message.text!r}")
-            await message.reply("❌ Неверный формат. Введите два курса — например:\n<code>93.15 12.85</code>")
+            await message.reply(
+                "❌ Неверный формат. Введите три курса — например:\n"
+                "<code>93.15 93.55 12.85</code>"
+            )
             return
 
-        a, b = pair
-        usd_markup, cny_markup = max(a, b), min(a, b)
+        usd_markup, usdt_markup, cny_markup = parsed
+        usd_markup = usd_markup.quantize(Decimal("0.0001"))
+        usdt_markup = usdt_markup.quantize(Decimal("0.0001"))
+        cny_markup = cny_markup.quantize(Decimal("0.0001"))
+
         usd_base = (usd_markup - Decimal("1.00")).quantize(Decimal("0.0001"))
+        usdt_base = (usdt_markup - Decimal("1.00")).quantize(Decimal("0.0001"))
         cny_base = (cny_markup / Decimal("1.02")).quantize(Decimal("0.0001"))
+        try:
+            usdt_cny_ratio = (usdt_markup / cny_markup).quantize(Decimal("0.01"))
+        except (InvalidOperation, DivisionByZero):
+            usdt_cny_ratio = Decimal("0.00")
 
         try:
-            await controller.add_rates(ust=float(usd_base), cny=float(cny_base), date=date.today())
-        except IntegrityError:
-            await message.reply("ℹ️ Курсы на сегодня уже зафиксированы.")
-            return
+            _, created = await controller.upsert_rates(
+                usd=float(usd_base),
+                usdt=float(usdt_base),
+                cny=float(cny_base),
+                date=date.today(),
+            )
         except Exception as e:
             logger.warning(f"❌ Ошибка сохранения курсов от {message.from_user.id}: {e}")
             await message.reply("⚠️ Не удалось сохранить курсы.")
             return
 
-        logger.info(f"💾 Курсы сохранены от пользователя {message.from_user.id}")
+        action = "сохранены" if created else "обновлены"
+        logger.info(f"💾 Курсы {action} от пользователя {message.from_user.id}")
 
     author = (message.from_user.username and f"@{message.from_user.username}") or str(message.from_user.id)
+    header_suffix = "" if created else " (обновление)"
     await bot.send_message(
         MANAGER_CHAT_ID,
         (
-            f"<b>📊 Курсы на {date.today():%d.%m.%Y} (от {author}):</b>\n\n"
+            f"<b>📊 Курсы на {date.today():%d.%m.%Y} (от {author}){header_suffix}:</b>\n\n"
             f"🇺🇸 USD (введено): <b>{usd_markup:.2f}₽</b>\n"
-            f"🇨🇳 CNY (введено): <b>{cny_markup:.2f}₽</b>\n\n"
+            f"💠 USDT (введено): <b>{usdt_markup:.2f}₽</b>\n"
+            f"🇨🇳 CNY (введено): <b>{cny_markup:.2f}₽</b>\n"
+            f"🔁 USDT/CNY: <b>{usdt_cny_ratio:.2f}</b>\n\n"
             f"🧮 База:\n"
             f"• USD(base) = {usd_base:.4f}₽\n"
+            f"• USDT(base) = {usdt_base:.4f}₽\n"
             f"• CNY(base) = {cny_base:.4f}₽"
         ),
     )
-    await message.reply("✅ Курсы получены и сохранены. Спасибо!")
+    await message.reply(f"✅ Курсы {action}. Спасибо!")
 
 
 # --- Entry point ---

--- a/controllers.py
+++ b/controllers.py
@@ -2,36 +2,54 @@ from typing import Optional
 from datetime import date
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func
-from sqlalchemy.exc import IntegrityError
 from models import CurrencyRates
 
 class CurrencyController:
     def __init__(self, session: AsyncSession):
         self.session = session
 
-    async def add_rates(self, ust: float, cny: float, date: date) -> CurrencyRates:
-        ust_cents = int(ust * 100)
+    async def upsert_rates(
+        self,
+        usd: float,
+        usdt: float,
+        cny: float,
+        date: date,
+    ) -> tuple[CurrencyRates, bool]:
+        usd_cents = int(usd * 100)
+        usdt_cents = int(usdt * 100)
         cny_fens = int(cny * 100)
 
-        ust_plus1_cents = int((ust + 1) * 100)
+        usd_plus1_cents = int((usd + 1) * 100)
+        usdt_plus1_cents = int((usdt + 1) * 100)
         cny_plus2p_fens = int((cny * 1.02) * 100)
+
+        existing = await self.get_rates_by_date(date)
+        if existing:
+            existing.ust_rub_cents = usd_cents
+            existing.usdt_rub_cents = usdt_cents
+            existing.cny_rub_fens = cny_fens
+            existing.ust_rub_plus1_cents = usd_plus1_cents
+            existing.usdt_rub_plus1_cents = usdt_plus1_cents
+            existing.cny_rub_plus2p_fens = cny_plus2p_fens
+
+            await self.session.commit()
+            await self.session.refresh(existing)
+            return existing, False
 
         rates = CurrencyRates(
             date=date,
-            ust_rub_cents=ust_cents,
+            ust_rub_cents=usd_cents,
+            usdt_rub_cents=usdt_cents,
             cny_rub_fens=cny_fens,
-            ust_rub_plus1_cents=ust_plus1_cents,
+            ust_rub_plus1_cents=usd_plus1_cents,
+            usdt_rub_plus1_cents=usdt_plus1_cents,
             cny_rub_plus2p_fens=cny_plus2p_fens,
         )
 
         self.session.add(rates)
-        try:
-            await self.session.commit()
-        except IntegrityError:
-            await self.session.rollback()
-            raise
+        await self.session.commit()
         await self.session.refresh(rates)
-        return rates
+        return rates, True
 
     async def get_rates_by_date(self, date: date) -> CurrencyRates | None:
         query = select(CurrencyRates).where(CurrencyRates.date == date)

--- a/models.py
+++ b/models.py
@@ -9,8 +9,11 @@ class CurrencyRates(Base):
     id = Column(Integer, primary_key=True)
     date = Column(Date, unique=True, nullable=False)
 
-    ust_rub_cents = Column(Integer, nullable=False)         # UST/RUB * 100
-    cny_rub_fens = Column(Integer, nullable=False)          # CNY/RUB * 100
+    ust_rub_cents = Column(Integer, nullable=False)         # USD/RUB base * 100
+    usdt_rub_cents = Column(Integer, nullable=False)        # USDT/RUB base * 100
+    cny_rub_fens = Column(Integer, nullable=False)          # CNY/RUB base * 100
 
-    ust_rub_plus1_cents = Column(Integer, nullable=False)   # (UST+1) * 100
-    cny_rub_plus2p_fens = Column(Integer, nullable=False)   # (CNY*1.02) * 100 
+    ust_rub_plus1_cents = Column(Integer, nullable=False)   # (USD + 1) * 100
+    usdt_rub_plus1_cents = Column(Integer, nullable=False)  # (USDT + 1) * 100
+    cny_rub_plus2p_fens = Column(Integer, nullable=False)   # (CNY * 1.02) * 100
+

--- a/static/script.js
+++ b/static/script.js
@@ -21,8 +21,10 @@ form.addEventListener('submit', async (e) => {
         row.innerHTML = `
             <td>${r.date}</td>
             <td>${r.ust_rub.toFixed(2)}</td>
+            <td>${r.usdt_rub.toFixed(2)}</td>
             <td>${r.cny_rub.toFixed(2)}</td>
             <td>${r.ust_rub_plus1.toFixed(2)}</td>
+            <td>${r.usdt_rub_plus1.toFixed(2)}</td>
             <td>${r.cny_rub_plus2p.toFixed(2)}</td>`;
         tbody.appendChild(row);
     });

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,8 +10,9 @@
 
     {% if latest_rate %}
     <div id="latest-rate">
-        Актуальный курс на {{ latest_rate.date }}:
+        Актуальные курсы на {{ latest_rate.date }}:
         USD/RUB {{ "%.2f"|format(latest_rate.ust_rub) }},
+        USDT/RUB {{ "%.2f"|format(latest_rate.usdt_rub) }},
         CNY/RUB {{ "%.2f"|format(latest_rate.cny_rub) }}
     </div>
     {% endif %}
@@ -26,8 +27,10 @@
             <tr>
                 <th>Дата</th>
                 <th>USD/RUB</th>
+                <th>USDT/RUB</th>
                 <th>CNY/RUB</th>
                 <th>USD+1</th>
+                <th>USDT+1</th>
                 <th>CNY+2%</th>
             </tr>
         </thead>
@@ -36,8 +39,10 @@
             <tr>
                 <td>{{ r.date }}</td>
                 <td>{{ "%.2f"|format(r.ust_rub) }}</td>
+                <td>{{ "%.2f"|format(r.usdt_rub) }}</td>
                 <td>{{ "%.2f"|format(r.cny_rub) }}</td>
                 <td>{{ "%.2f"|format(r.ust_rub_plus1) }}</td>
+                <td>{{ "%.2f"|format(r.usdt_rub_plus1) }}</td>
                 <td>{{ "%.2f"|format(r.cny_rub_plus2p) }}</td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
## Summary
- add USDT storage columns and an upsert helper so the current day’s rates can be updated without deleting data
- extend the bot flow to accept USD, USDT and CNY, compute the USDT/CNY cross-rate, and notify the manager about updates
- expose the new USDT fields through the API, web UI, and a migration to keep historical rows compatible

## Testing
- python -m compileall .


------
https://chatgpt.com/codex/tasks/task_e_68d120bc5740832ca971fa4c076a4140