### PR TITLE
Update manual currency input flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Telegram bot for manual collection and storage of currency rates with API access
 
 ## Features
 
-- Daily automatic requests for UST/RUB and CNY/RUB rates
+- Daily automatic requests for USD/RUB, CNY/RUB and USDT (USD/CNY) values
 - Whitelist-based access control
 - Reply-based rate collection
 - Automatic conversion to smallest units
 - FastAPI backend for rate retrieval
 - PostgreSQL storage
-- Only the first valid rates per day are saved
+- Manual values can be updated throughout the day
 
 ## Setup
 
@@ -66,8 +66,9 @@ Example response:
 ```json
 {
   "date": "2025-05-21",
-  "ust_rub": 93.15,
+  "usd_rub": 93.15,
   "cny_rub": 12.85,
+  "usdt_usd_cny": 7.25,
   "ust_rub_plus1": 94.15,
   "cny_rub_plus2p": 13.107
 }
@@ -75,14 +76,12 @@ Example response:
 
 ## Bot Usage
 
-1. The bot automatically sends two messages at 09:00 MSK on weekdays (Mon-Fri):
-   - "Введите курс UST/RUB на сегодня"
-   - "Введите курс CNY/RUB на сегодня"
+1. The bot automatically sends a message at 10:00 MSK on weekdays (Mon-Fri) asking for three values: USD/RUB, CNY/RUB and USDT (USD/CNY)
 2. If the rates are still not provided, the bot sends a reminder at 12:00 MSK on weekdays
-3. Reply to these messages with the rates
+3. Reply to the message with three numbers on separate lines (USD/RUB, CNY/RUB, USDT (USD/CNY))
 4. Only messages from users listed in `ALLOWED_USERS` (and `TARGET_USER_ID` for backward compatibility) sent in a private chat with the bot are processed
-5. After both rates are collected, they are automatically saved to the database
-6. Repeated submissions on the same day are ignored
+5. After the values are collected, they are automatically saved to the database
+6. Repeated submissions on the same day overwrite the previous entry
 
 ## Security
 

--- a/api.py
+++ b/api.py
@@ -20,9 +20,9 @@ async def get_db_session() -> AsyncGenerator[AsyncSession, None]:
 
 class CurrencyRatesResponse(BaseModel):
     date: date
-    ust_rub: float
-    usdt_rub: float
+    usd_rub: float
     cny_rub: float
+    usdt_usd_cny: float
 
     class Config:
         from_attributes = True
@@ -39,9 +39,9 @@ async def get_today_rates(session: AsyncSession = Depends(get_db_session)):
 
     return {
         "date": rates.date,
-        "ust_rub": rates.ust_rub_cents / 100,
-        "usdt_rub": rates.usdt_rub_cents / 100,
+        "usd_rub": rates.ust_rub_cents / 100,
         "cny_rub": rates.cny_rub_fens / 100,
+        "usdt_usd_cny": rates.usdt_rub_cents / 100,
     }
 
 
@@ -63,9 +63,9 @@ async def get_rates_by_date(
 
     return {
         "date": rates.date,
-        "ust_rub": rates.ust_rub_cents / 100,
-        "usdt_rub": rates.usdt_rub_cents / 100,
+        "usd_rub": rates.ust_rub_cents / 100,
         "cny_rub": rates.cny_rub_fens / 100,
+        "usdt_usd_cny": rates.usdt_rub_cents / 100,
     }
 
 
@@ -81,9 +81,9 @@ async def get_rates_range(
     return [
         {
             "date": r.date,
-            "ust_rub": r.ust_rub_cents / 100,
-            "usdt_rub": r.usdt_rub_cents / 100,
+            "usd_rub": r.ust_rub_cents / 100,
             "cny_rub": r.cny_rub_fens / 100,
+            "usdt_usd_cny": r.usdt_rub_cents / 100,
         }
         for r in result
     ]
@@ -98,9 +98,9 @@ async def index(request: Request, session: AsyncSession = Depends(get_db_session
     week_rates = [
         {
             "date": r.date,
-            "ust_rub": r.ust_rub_cents / 100,
-            "usdt_rub": r.usdt_rub_cents / 100,
+            "usd_rub": r.ust_rub_cents / 100,
             "cny_rub": r.cny_rub_fens / 100,
+            "usdt_usd_cny": r.usdt_rub_cents / 100,
         }
         for r in week_rates_models
     ]
@@ -110,9 +110,9 @@ async def index(request: Request, session: AsyncSession = Depends(get_db_session
     if latest:
         latest_data = {
             "date": latest.date,
-            "ust_rub": latest.ust_rub_cents / 100,
-            "usdt_rub": latest.usdt_rub_cents / 100,
+            "usd_rub": latest.ust_rub_cents / 100,
             "cny_rub": latest.cny_rub_fens / 100,
+            "usdt_usd_cny": latest.usdt_rub_cents / 100,
         }
 
     context = {

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,7 @@ import os
 import re
 import asyncio
 from datetime import date
-from decimal import Decimal, DivisionByZero, InvalidOperation
+from decimal import Decimal
 
 from aiogram import Bot, Dispatcher, F
 from aiogram.client.default import DefaultBotProperties
@@ -60,8 +60,8 @@ MANAGER_CHAT_ID = int(os.getenv("MANAGER_CHAT_ID"))
 
 
 CURRENCY_PROMPT = (
-    "📥 Введите курсы USD, USDT и CNY (в рублях) тремя строками:\n\n"
-    "Пример:\n<code>93.15\n93.40\n12.85</code>"
+    "📥 Введите курсы USD/RUB, CNY/RUB и USDT (USD/CNY) тремя строками:\n\n"
+    "Пример:\n<code>93.15\n12.85\n7.25</code>"
 )
 
 
@@ -113,25 +113,20 @@ async def handle_currency_message(message: Message) -> None:
             logger.info(f"⚠️ Неверный формат от {message.from_user.id}: {message.text!r}")
             await message.reply(
                 "❌ Неверный формат. Введите три значения — например:\n"
-                "<code>93.15\n93.40\n12.85</code>"
+                "<code>93.15\n12.85\n7.25</code>"
             )
             return
 
-        usd_rate, usdt_rate, cny_rate = parsed
+        usd_rate, cny_rate, usdt_usd_cny = parsed
         usd_rate = usd_rate.quantize(Decimal("0.0001"))
-        usdt_rate = usdt_rate.quantize(Decimal("0.0001"))
         cny_rate = cny_rate.quantize(Decimal("0.0001"))
-
-        try:
-            usdt_cny_ratio = (usdt_rate / cny_rate).quantize(Decimal("0.01"))
-        except (InvalidOperation, DivisionByZero):
-            usdt_cny_ratio = None
+        usdt_usd_cny = usdt_usd_cny.quantize(Decimal("0.0001"))
 
         try:
             _, created = await controller.upsert_rates(
-                usd=usd_rate,
-                usdt=usdt_rate,
-                cny=cny_rate,
+                usd_rub=usd_rate,
+                cny_rub=cny_rate,
+                usdt_usd_cny=usdt_usd_cny,
                 date=date.today(),
             )
         except Exception as e:
@@ -148,10 +143,9 @@ async def handle_currency_message(message: Message) -> None:
         MANAGER_CHAT_ID,
         (
             f"<b>📊 Курсы на {date.today():%d.%m.%Y} (от {author}){header_suffix}:</b>\n\n"
-            f"🇺🇸 USD: <b>{usd_rate:.2f}₽</b>\n"
-            f"💠 USDT: <b>{usdt_rate:.2f}₽</b>\n"
-            f"🇨🇳 CNY: <b>{cny_rate:.2f}₽</b>\n"
-            + (f"🔁 USDT/CNY: <b>{usdt_cny_ratio:.2f}</b>\n" if usdt_cny_ratio is not None else "")
+            f"🇺🇸 USD/RUB: <b>{usd_rate:.2f}</b>\n"
+            f"🇨🇳 CNY/RUB: <b>{cny_rate:.2f}</b>\n"
+            f"💠 USDT (USD/CNY): <b>{usdt_usd_cny:.2f}</b>\n"
         ),
     )
     await message.reply(f"✅ Курсы {action}. Спасибо!")

--- a/controllers.py
+++ b/controllers.py
@@ -13,27 +13,27 @@ class CurrencyController:
 
     async def upsert_rates(
         self,
-        usd: Decimal,
-        usdt: Decimal,
-        cny: Decimal,
+        usd_rub: Decimal,
+        cny_rub: Decimal,
+        usdt_usd_cny: Decimal,
         date: date,
     ) -> tuple[CurrencyRates, bool]:
-        usd = usd.quantize(Decimal("0.01"))
-        usdt = usdt.quantize(Decimal("0.01"))
-        cny = cny.quantize(Decimal("0.01"))
+        usd_rub = usd_rub.quantize(Decimal("0.01"))
+        cny_rub = cny_rub.quantize(Decimal("0.01"))
+        usdt_usd_cny = usdt_usd_cny.quantize(Decimal("0.01"))
 
-        usd_cents = int(usd * 100)
-        usdt_cents = int(usdt * 100)
-        cny_fens = int(cny * 100)
+        usd_cents = int(usd_rub * 100)
+        cny_fens = int(cny_rub * 100)
+        usdt_basis_points = int(usdt_usd_cny * 100)
 
         existing = await self.get_rates_by_date(date)
         if existing:
             existing.ust_rub_cents = usd_cents
-            existing.usdt_rub_cents = usdt_cents
             existing.cny_rub_fens = cny_fens
+            existing.usdt_rub_cents = usdt_basis_points
             existing.ust_rub_plus1_cents = usd_cents
-            existing.usdt_rub_plus1_cents = usdt_cents
             existing.cny_rub_plus2p_fens = cny_fens
+            existing.usdt_rub_plus1_cents = usdt_basis_points
 
             await self.session.commit()
             await self.session.refresh(existing)
@@ -42,11 +42,11 @@ class CurrencyController:
         rates = CurrencyRates(
             date=date,
             ust_rub_cents=usd_cents,
-            usdt_rub_cents=usdt_cents,
             cny_rub_fens=cny_fens,
+            usdt_rub_cents=usdt_basis_points,
             ust_rub_plus1_cents=usd_cents,
-            usdt_rub_plus1_cents=usdt_cents,
             cny_rub_plus2p_fens=cny_fens,
+            usdt_rub_plus1_cents=usdt_basis_points,
         )
 
         self.session.add(rates)

--- a/models.py
+++ b/models.py
@@ -10,12 +10,12 @@ class CurrencyRates(Base):
     date = Column(Date, unique=True, nullable=False)
 
     ust_rub_cents = Column(Integer, nullable=False)         # USD/RUB * 100
-    usdt_rub_cents = Column(Integer, nullable=False)        # USDT/RUB * 100
     cny_rub_fens = Column(Integer, nullable=False)          # CNY/RUB * 100
+    usdt_rub_cents = Column(Integer, nullable=False)        # USDT (USD/CNY) * 100
 
     # Legacy columns kept for compatibility with older dumps. They duplicate the
     # manually введённые значения и синхронизируются контроллером.
     ust_rub_plus1_cents = Column(Integer, nullable=False)
-    usdt_rub_plus1_cents = Column(Integer, nullable=False)
     cny_rub_plus2p_fens = Column(Integer, nullable=False)
+    usdt_rub_plus1_cents = Column(Integer, nullable=False)
 

--- a/static/script.js
+++ b/static/script.js
@@ -20,9 +20,9 @@ form.addEventListener('submit', async (e) => {
         const row = document.createElement('tr');
         row.innerHTML = `
             <td>${r.date}</td>
-            <td>${r.ust_rub.toFixed(2)}</td>
-            <td>${r.usdt_rub.toFixed(2)}</td>
-            <td>${r.cny_rub.toFixed(2)}</td>`;
+            <td>${r.usd_rub.toFixed(2)}</td>
+            <td>${r.cny_rub.toFixed(2)}</td>
+            <td>${r.usdt_usd_cny.toFixed(2)}</td>`;
         tbody.appendChild(row);
     });
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,9 +11,9 @@
     {% if latest_rate %}
     <div id="latest-rate">
         Актуальные курсы на {{ latest_rate.date }}:
-        USD/RUB {{ "%.2f"|format(latest_rate.ust_rub) }},
-        USDT/RUB {{ "%.2f"|format(latest_rate.usdt_rub) }},
-        CNY/RUB {{ "%.2f"|format(latest_rate.cny_rub) }}
+        USD/RUB {{ "%.2f"|format(latest_rate.usd_rub) }},
+        CNY/RUB {{ "%.2f"|format(latest_rate.cny_rub) }},
+        USDT (USD/CNY) {{ "%.2f"|format(latest_rate.usdt_usd_cny) }}
     </div>
     {% endif %}
 
@@ -27,17 +27,17 @@
             <tr>
                 <th>Дата</th>
                 <th>USD/RUB</th>
-                <th>USDT/RUB</th>
                 <th>CNY/RUB</th>
+                <th>USDT (USD/CNY)</th>
             </tr>
         </thead>
         <tbody id="rates-table-body">
             {% for r in default_rates %}
             <tr>
                 <td>{{ r.date }}</td>
-                <td>{{ "%.2f"|format(r.ust_rub) }}</td>
-                <td>{{ "%.2f"|format(r.usdt_rub) }}</td>
+                <td>{{ "%.2f"|format(r.usd_rub) }}</td>
                 <td>{{ "%.2f"|format(r.cny_rub) }}</td>
+                <td>{{ "%.2f"|format(r.usdt_usd_cny) }}</td>
             </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- adjust the bot to request USD/RUB, CNY/RUB, and USDT (USD/CNY) values and stop calculating the ratio automatically
- store and expose the new values through the controller, API, frontend template, and script
- refresh project documentation to describe the new manual-input workflow

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d136cfd66c832c9e76e37dac383123